### PR TITLE
feat: Create new Fleets for all variants #1090

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [NebraLtd]

--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -1,0 +1,36 @@
+name: update fleet files on master branch creation
+on:
+  create:
+
+jobs:
+  template-update:
+    runs-on: ubuntu-latest
+    if:  ${{ contains(github.event.ref, 'master') }}
+    steps:
+      - name: checkout master
+        uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: setup python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: generate files from string templates
+        run: |
+          pip install https://codeload.github.com/nebraltd/hm-pyhelper/zip/22e2006
+          pip install pyyaml
+          python .github/workflows/scripts/generate_files.py ${{github.repository}}
+      - name: get variant's docker compose file from helium miner software
+        run: |
+          .github/workflows/scripts/update_files.sh ${{github.repository}}
+      - name: Push updated docker compose and balena.yml files
+        if: success()
+        uses: test-room-7/action-update-file@v1
+        with:
+          branch: master
+          file-path: |
+            balena.yml
+            docker-compose.yml
+            README.md
+          commit-msg: create balena.yml, docker-compose.yml and README.md
+          github-token: ${{ secrets.MR_BUMP }}

--- a/.github/workflows/scripts/generate_files.py
+++ b/.github/workflows/scripts/generate_files.py
@@ -1,0 +1,57 @@
+"""
+The script is meant ot be used by github actions and takes the complete repository name
+as first and only argument.
+eg. python generate_files.py NebraLtd/hnt_rak-v1
+"""
+import sys
+import os
+import yaml
+from string import Template
+from hm_pyhelper.hardware_definitions import variant_definitions
+
+# form base paths
+here = os.path.dirname(os.path.abspath(__file__))
+templates_folder = os.path.join(here, '../templates')
+readme_filename = os.path.join(here, '../../../README.md')
+balena_yml_filename = os.path.join(here, '../../../balena.yml')
+
+# extract repository name, variant and vendor name.
+REPOSITORY = sys.argv[1].split('/')[1]
+VARIANT = REPOSITORY.split('_')[1]
+VENDOR = VARIANT.split('-')[0]
+
+# create template dict
+variant_defs = variant_definitions[VARIANT]
+template_data = {}
+template_data['VARIANT_NAME'] = VARIANT
+template_data['REPO_NAME'] = REPOSITORY
+template_data['VENDOR'] = VENDOR if VENDOR.isupper() else VENDOR.capitalize()
+template_data['FLEET'] = f"hnt_{VARIANT}_mainnet_openfleet"
+template_data['DEFAULT_DEVICE_NAME'] = variant_defs["BALENA_DEVICE_TYPE"][0]
+
+# update supported models
+supported_models_key = 'SUPPORTED_MODELS'
+supported_models = [variant_defs['FRIENDLY']]
+if supported_models_key in variant_defs.keys():
+    supported_models = variant_defs[supported_models_key]
+models = ", ".join(supported_models)
+template_data['SUPPORTED_MODELS'] = models
+
+# render templates
+balena_yml_template = Template(open(os.path.join(templates_folder,
+                                                 'balena.yml.template')).read())
+readme_template = Template(open(os.path.join(templates_folder,
+                                             'README.md.template')).read())
+balena_output = balena_yml_template.substitute(template_data)
+readme_output = readme_template.substitute(template_data)
+
+# load into yaml and update supported device types and models
+balena_yaml = yaml.safe_load(balena_output)
+balena_yaml["data"]["supportedDeviceTypes"] = variant_defs["BALENA_DEVICE_TYPE"]
+
+# write out the rendered data.
+with open(balena_yml_filename, 'w') as f:
+    f.write(yaml.dump(balena_yaml, indent=2, sort_keys=False))
+
+with open(readme_filename, 'w') as f:
+    f.write(readme_output)

--- a/.github/workflows/scripts/update_files.sh
+++ b/.github/workflows/scripts/update_files.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# this is meant to be used by github actions.
+# takes the full github repository name as argument eg. update_files.sh NebraLtd/hnt_rak-v1
+set -eou pipefail
+
+# extract variant and repo directory
+repo_name=$1
+repo_dir=$(echo ${repo_name} | cut -d '/' -f 2)
+variant_name=$(echo ${repo_dir} | cut -d '_' -f 2)
+
+# update docker-compose
+cd /home/runner/work/${repo_dir}/${repo_dir}
+rm -f docker-compose.yml
+wget "https://raw.githubusercontent.com/NebraLtd/helium-miner-software/master/device-compose-files/docker-compose-${variant_name}.yml" -O docker-compose.yml

--- a/.github/workflows/templates/README.md.template
+++ b/.github/workflows/templates/README.md.template
@@ -1,0 +1,2 @@
+# Introduction
+Nebra's Balena OpenFleet repository for $VENDOR Helium Miners ($SUPPORTED_MODELS).

--- a/.github/workflows/templates/balena.yml.template
+++ b/.github/workflows/templates/balena.yml.template
@@ -1,0 +1,30 @@
+name: $REPO_NAME
+type: sw.application
+description: >-
+  Manage your $VENDOR Helium Miners ($SUPPORTED_MODELS) remotely using Nebra and BalenaCloud.
+post-provisioning: >-
+  ## Usage instructions
+
+
+  Once your device joins the fleet you'll need to allow some time for it to download the application and start forwarding packets to the Helium Network.
+
+
+  For detailed instructions on how to use Nebra Helium $VARIANT_NAME check out [our GitHub repo](https://github.com/NebraLtd/$REPO_NAME).
+
+
+  For support you can [open an issue](https://github.com/NebraLtd/$REPO_NAME/issues) on the repo or reach out to us via one of the methods listed [on our support page](https://helium.nebra.com/support).
+assets:
+  repository:
+    type: blob.asset
+    data:
+      url: "https://github.com/NebraLtd/$REPO_NAME"
+  logo:
+    type: blob.asset
+    data:
+      url: >-
+        https://cdn.shopify.com/s/files/1/0071/2281/3001/files/Nebra-Icon-Blue_bb758eaa-b10d-4ea6-a55e-babd69135b69.png?v=1620938774
+data:
+  defaultDeviceType: $DEFAULT_DEVICE_NAME
+  supportedDeviceTypes:
+    - $DEFAULT_DEVICE_NAME
+version: 0.0.1

--- a/.github/workflows/update-files.yml
+++ b/.github/workflows/update-files.yml
@@ -1,0 +1,23 @@
+name: Update Files
+on:
+  repository_dispatch:
+    types: [file-update]
+  workflow_dispatch:
+jobs:
+  file-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: master
+      - run: |
+          .github/workflows/scripts/update_files.sh ${{ github.repository }}
+      - name: Push updated docker compose file
+        if: success()
+        uses: test-room-7/action-update-file@v1
+        with:
+          branch: master
+          file-path: |
+            docker-compose.yml
+          commit-msg: Update docker-compose.yml
+          github-token: ${{ secrets.MR_BUMP }}


### PR DESCRIPTION
* workflows and templates for downstream repos created from this repo.

** Create new Fleets for all variants #1090 **

- Link: https://github.com/NebraLtd/hm-dashboard/issues/1090
- Summary: template repository to create openfleet repositories.
- 
**How**
When one create a new fleet repo as per our nomenclature from this template repository. On create workflow will run and creates its balena.yml and README.md. 
It will fetch appropirate docker-compose.yml as well once we have agreed on the filenames for it on helium-miner-software side.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names